### PR TITLE
dnscrypt-proxy 0.9.4 requires --tcp-only (-T) to force TCP usage.

### DIFF
--- a/dnscrypt-winclient/ApplicationForm.cs
+++ b/dnscrypt-winclient/ApplicationForm.cs
@@ -117,7 +117,7 @@ namespace dnscrypt_winclient
 
 				if (this.tcp_checkbox.Checked)
 				{
-					this.CryptProc.Arguments = "-t " + Convert.ToInt16(this.tcp_port_number.Text);
+					this.CryptProc.Arguments = "-T -t " + Convert.ToInt16(this.tcp_port_number.Text);
 				}
 		
 				this.CryptHandle = Process.Start(this.CryptProc);


### PR DESCRIPTION
The --tcp-port option is gone in the just-released dnscrypt-proxy 0.9.4.

-T (alias --tcp-only) should be used to force TCP.

-t is now an alias for --resolver-port, that changes the resolver port, but doesn't force TCP.

OpenDNS supports TCP and UDP on ports 53, 443 and 5353.

When UDP is available (and routers are usually just hijacking port 53), it is preferred over TCP, especially on Windows since the UDP->TCP fallback is pretty slow.

It would be awesome if dnscrypt-winclient could let the user pick the port and the protocol he wants to use.
