### PR TITLE
The -t switch has been deprecated for a while and is gone in 1.1.0

### DIFF
--- a/dnscrypt-winclient/ApplicationForm.cs
+++ b/dnscrypt-winclient/ApplicationForm.cs
@@ -148,16 +148,19 @@ namespace dnscrypt_winclient
 					this.CryptProc.Arguments = "-T";
 				}
 
-				this.CryptProc.Arguments += " -t " + this.portBox.SelectedItem.ToString();
-
 				if (this.ipv6Radio.Checked)
 				{
-					this.CryptProc.Arguments += " --resolver-address=2620:0:ccd::2";
+					this.CryptProc.Arguments += " --resolver-address=[2620:0:ccd::2]";
 				}
 				else if (this.parentalControlsRadio.Checked)
 				{
 					this.CryptProc.Arguments += " --resolver-address=208.67.220.123";
 				}
+				else
+				{
+					this.CryptProc.Arguments += " --resolver-address=208.67.220.220";
+				}
+				this.CryptProc.Arguments += ":" + this.portBox.SelectedItem.ToString();
 
 				if (this.gatewayCheckbox.Checked)
 				{


### PR DESCRIPTION
Hello,

The -t switch is gone, in order to be consistent with the server-side version of the proxy (that will hopefully get released soon).

Version 1.1.0 is in RC, and I'd like to release the final one in the next few days, but that would break dnscrypt-winclient :(
